### PR TITLE
Workaround for Edge tab reloading

### DIFF
--- a/platform/edge/vapi-background.js
+++ b/platform/edge/vapi-background.js
@@ -605,16 +605,15 @@ vAPI.tabs.reload = function(tabId /*, flags*/) {
         return;
     }
 
-    var onReloaded = function() {
-        // https://code.google.com/p/chromium/issues/detail?id=410868#c8
-        if ( browser.runtime.lastError ) {
-            /* noop */
-        }
-    };
-
     // Workaround for Edge tab reloading
-    tabUrl = browser.tabs.get(tabId).url;
-    browser.tabs.update(tabId, {active: true, url: tabUrl}, onReloaded);
+    // see: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/reload#Browser_compatibility
+    browser.tabs.get(tabId, function(tab){
+        if (browser.tabs.lastError || !tab) {
+            /* noop */
+            return;
+        }
+        vAPI.tabs.replace(tabId, tab.url);
+    });
 };
 
 /******************************************************************************/

--- a/platform/edge/vapi-background.js
+++ b/platform/edge/vapi-background.js
@@ -612,7 +612,9 @@ vAPI.tabs.reload = function(tabId /*, flags*/) {
         }
     };
 
-    browser.tabs.reload(tabId, onReloaded);
+    // Workaround for Edge tab reloading
+    tabUrl = browser.tabs.get(tabId).url;
+    browser.tabs.update(tabId, {active: true, url: tabUrl}, onReloaded);
 };
 
 /******************************************************************************/


### PR DESCRIPTION
Fixes reloading after pressing reload button and logger works now; See #6 