### PR TITLE
Disable cloud support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 ***
 
+Please see [μBlock-Edge FAQs](https://github.com/nikrolls/uBlock-Edge/wiki/%CE%BCBlock-Edge-FAQs) for more information about this fork.
+
+***
+
 ##### BEWARE! uBlock Origin is COMPLETELY UNRELATED to the web site ublock.org**
 
 The donations sought by the [individual](https://github.com/chrisaljoudi/) behind `ublock.org` (_"to keeps uBlock development possible"_, [a misrepresentation](https://en.wikipedia.org/wiki/UBlock_Origin#uBlock_.28ublock.org.29)) are _not_ benefiting any of those who contributed most to create uBlock Origin ([developers](https://github.com/gorhill/uBlock/graphs/contributors), [translators](https://crowdin.com/project/ublock), and all those who put efforts in opening detailed issues). For the differences between uBlock Origin and uBlock, see the unbiased [Wikipedia article](https://en.wikipedia.org/wiki/UBlock_Origin).

--- a/platform/edge/vapi-background.js
+++ b/platform/edge/vapi-background.js
@@ -1314,7 +1314,7 @@ vAPI.cloud = (function() {
         pull: noop,
         getOptions: noop,
         setOptions: noop,
-        supported: false
+        isSupported: false
     };
 })();
 

--- a/platform/edge/vapi-background.js
+++ b/platform/edge/vapi-background.js
@@ -1313,7 +1313,8 @@ vAPI.cloud = (function() {
         push: noop,
         pull: noop,
         getOptions: noop,
-        setOptions: noop
+        setOptions: noop,
+        supported: false
     };
 })();
 

--- a/src/js/messaging.js
+++ b/src/js/messaging.js
@@ -669,6 +669,11 @@ var onMessage = function(request, sender, callback) {
     case 'cloudPush':
         return vAPI.cloud.push(request.datakey, request.data, callback);
 
+    case 'cloudIsSupported':
+        if (typeof vAPI.cloud.isSupported !== "undefined") {
+            callback(vAPI.cloud.isSupported);
+        }
+
     default:
         break;
     }

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -219,11 +219,31 @@ var onUserSettingsReceived = function(details) {
     uDom('#restoreFilePicker').on('change', handleImportFilePicker);
 };
 
+var checkCloudSupport = function() {
+    // Only disable when support is explicitly set to false
+    if ( typeof vAPI.cloud.supported !== 'undefined' && vAPI.cloud.supported === false ) {
+        // Force disabling of cloud storage if enabled previously
+        messaging.send(
+            'dashboard',
+            {
+                what: 'userSettings',
+                name: "cloudStorageEnabled",
+                value: false
+            }
+        );
+        uDom.nodeFromId('cloud-storage-enabled').disabled = true;
+        uDom.nodeFromSelector('#cloud-storage-enabled ~ .fa.info').title = "Cloud sync not supported in this browser";
+        return;
+    }
+    return;
+}
+
 /******************************************************************************/
 
 uDom.onLoad(function() {
     messaging.send('dashboard', { what: 'userSettings' }, onUserSettingsReceived);
     messaging.send('dashboard', { what: 'getLocalData' }, onLocalDataReceived);
+    checkCloudSupport();
 });
 
 /******************************************************************************/

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -219,9 +219,9 @@ var onUserSettingsReceived = function(details) {
     uDom('#restoreFilePicker').on('change', handleImportFilePicker);
 };
 
-var checkCloudSupport = function() {
+var onCloudSupportReceived = function(isSupported) {
     // Only disable when support is explicitly set to false
-    if ( typeof vAPI.cloud.supported !== 'undefined' && vAPI.cloud.supported === false ) {
+    if ( isSupported === false ) {
         // Force disabling of cloud storage if enabled previously
         messaging.send(
             'dashboard',
@@ -233,9 +233,7 @@ var checkCloudSupport = function() {
         );
         uDom.nodeFromId('cloud-storage-enabled').disabled = true;
         uDom.nodeFromSelector('#cloud-storage-enabled ~ .fa.info').title = "Cloud sync not supported in this browser";
-        return;
     }
-    return;
 }
 
 /******************************************************************************/
@@ -243,7 +241,7 @@ var checkCloudSupport = function() {
 uDom.onLoad(function() {
     messaging.send('dashboard', { what: 'userSettings' }, onUserSettingsReceived);
     messaging.send('dashboard', { what: 'getLocalData' }, onLocalDataReceived);
-    checkCloudSupport();
+    messaging.send('cloudWidget', { what: 'cloudIsSupported' }, onCloudSupportReceived);
 });
 
 /******************************************************************************/


### PR DESCRIPTION
As Edge is not going to enable cloud syncing in the near future, this PR disables the ability to enable cloud support and inform the user.

Method is implemented in the general files and should work for all other browsers as well as it relies on the platform-dependent `vapi-background.js` that needs to explicitly set `isSupported` to `false`.

Any feedback is welcome.