### PR TITLE
Fix list updating inifite loading

### DIFF
--- a/platform/edge/vapi-background.js
+++ b/platform/edge/vapi-background.js
@@ -926,7 +926,12 @@ vAPI.messaging.broadcast = function(message) {
         if ( this.ports.hasOwnProperty(portName) === false ) {
             continue;
         }
-        this.ports[portName].postMessage(messageWrapper);
+        // Do not stop broadcasting upon errors,
+        // workaround for Edge 'handle is invalid' error
+        try {
+            this.ports[portName].postMessage(messageWrapper);
+        } catch(e) {
+        }
     }
 };
 


### PR DESCRIPTION
In some cases the updating of lists seemed to hang and spit out an `handle is invalid` error. For me, this revolved around the broadcast method that seemed to fail in some cases. From trial and error, I found that most cases it fails when a port has no `sender` object attached. This worked in most cases, but not all. 

Mozilla and MSDN have good docs on messaging, but as it works well in Chrome this seems to be Edge-specific (for which I couldn't find any docs).

Perhaps this is not the best solution, as we don't know the actual cause of the fail... But I'd like to argue to have this implement anyhow, as any weird error shouldn't stop the function from broadcasting the message.

Would fix #18. Both applying a new list selection and visually updating lists by showing the progress seem to work now.