### PR TITLE
Workaround for YouTube / window.onload issue #16

### DIFF
--- a/platform/edge/manifest.json
+++ b/platform/edge/manifest.json
@@ -37,6 +37,12 @@
             "js": ["js/scriptlets/subscriber.js"],
             "run_at": "document_idle",
             "all_frames": false
+        },
+        {
+            "matches": ["*://*.youtube.com/*"],
+            "js": ["js/window-onload-workaround.js"],
+            "run_at": "document_start",
+            "all_frames": false
         }
     ],
     "incognito": "split",

--- a/platform/edge/window-onload-workaround.js
+++ b/platform/edge/window-onload-workaround.js
@@ -1,0 +1,34 @@
+/*******************************************************************************
+
+ uBlock Origin - a browser extension to block requests.
+ Copyright (C) 2014-2016 The uBlock Origin authors
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see {http://www.gnu.org/licenses/}.
+
+ Home: https://github.com/gorhill/uBlock
+ */
+
+'use strict';
+
+// Workaround Edge issue where window.onload is not fired under certain circumstances
+
+/******************************************************************************/
+
+(function() {
+
+document.addEventListener('DOMContentLoaded', () => window.dispatchEvent(new Event('load')));
+
+})();
+
+/******************************************************************************/


### PR DESCRIPTION
This is a temporary workaround for #16 to ensure that `window.onload` is fired even when Edge's bug prevents it from doing so.

Investigation of YouTube's code indicates that there are no side-effects to firing `window.onload` more than once, so there's nothing required to check if the bug is occurring or not; all that's needed is to match the domain.

Once the issue is fixed in Edge this can be removed. 