### PR TITLE
Send background downloads to the foreground

### DIFF
--- a/platform/edge/vapi-client.js
+++ b/platform/edge/vapi-client.js
@@ -505,6 +505,14 @@ vAPI.messaging = {
     }
 };
 
+// Downloads don't currently work from background pages
+// so we listen for forwarded downloads here
+vAPI.messaging.addChannelListener('foregroundDownload', (message) => {
+    if (message.what === 'foregroundDownload') {
+        vAPI.download(message.details);
+    }
+});
+
 /******************************************************************************/
 
 vAPI.shutdown.add(function() {

--- a/platform/edge/vapi-common.js
+++ b/platform/edge/vapi-common.js
@@ -49,7 +49,14 @@ var setScriptDirection = function(language) {
 /******************************************************************************/
 
 vAPI.download = function(details) {
-    if ( !details.url ) {
+    if (!details.url) {
+        return;
+    }
+
+    if (window.location.pathname.endsWith('background.html')) {
+        // Downloads don't currently work from background pages
+        // so we send it to the foreground for download
+        vAPI.messaging.broadcast({what:'foregroundDownload', details});
         return;
     }
 
@@ -61,7 +68,6 @@ vAPI.download = function(details) {
             content = content.replace(/\r?\n/g, '\r\n');
         }
         const blob = new Blob([content], {type: contentType});
-        // Currently not working from background pages
         window.navigator.msSaveBlob(blob, details.filename);
     }
 };


### PR DESCRIPTION
This works around a temporary issue with Edge where background downloads are not supported.

Fixes #25.