### PR TITLE
Edge doesn't support intercepting pings

### DIFF
--- a/platform/edge/vapi-background.js
+++ b/platform/edge/vapi-background.js
@@ -1285,14 +1285,16 @@ vAPI.net.registerListeners = function() {
         // Chromium 48 and lower does not support `ping` type.
         // Chromium 56 and higher does support `csp_report` stype.
         if ( is_v49_55 && crapi.onBeforeSendHeaders.hasListener(onBeforeSendHeaders) === false ) {
-            crapi.onBeforeSendHeaders.addListener(
-                onBeforeSendHeaders,
-                {
-                    'urls': [ '<all_urls>' ],
-                    'types': [ 'ping' ]
-                },
-                [ 'blocking', 'requestHeaders' ]
-            );
+            try {
+                crapi.onBeforeSendHeaders.addListener(
+                    onBeforeSendHeaders,
+                    {
+                        'urls': [ '<all_urls>' ],
+                        'types': [ 'ping' ]
+                    },
+                    [ 'blocking', 'requestHeaders' ]
+                );
+            } catch (e) {}
         }
  
         if ( crapi.onHeadersReceived.hasListener(onHeadersReceived) === false ) {


### PR DESCRIPTION
A simple try/catch means that it should working automatically once support is added.